### PR TITLE
[SC-425] Adding Circle CCTP support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           ARBITRUM_NOVA_RPC_URL: ${{secrets.ARBITRUM_NOVA_RPC_URL}}
           GNOSIS_CHAIN_RPC_URL: ${{secrets.GNOSIS_CHAIN_RPC_URL}}
           BASE_RPC_URL: ${{secrets.BASE_RPC_URL}}
+          POLYGON_RPC_URL: ${{secrets.POLYGON_RPC_URL}}
         run: FOUNDRY_PROFILE=ci forge test
 
   coverage:
@@ -58,6 +59,7 @@ jobs:
           ARBITRUM_NOVA_RPC_URL: ${{secrets.ARBITRUM_NOVA_RPC_URL}}
           GNOSIS_CHAIN_RPC_URL: ${{secrets.GNOSIS_CHAIN_RPC_URL}}
           BASE_RPC_URL: ${{secrets.BASE_RPC_URL}}
+          POLYGON_RPC_URL: ${{secrets.POLYGON_RPC_URL}}
         run: forge coverage --report summary --report lcov
 
       # To ignore coverage for certain directories modify the paths in this step as needed. The

--- a/src/CCTPReceiver.sol
+++ b/src/CCTPReceiver.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+/**
+ * @title CCTPReceiver
+ * @notice Receive messages from CCTP-style bridge.
+ */
+abstract contract CCTPReceiver {
+
+    address public immutable l2CrossDomain;
+    uint32 public immutable  sourceDomain;
+    address public immutable l1Authority;
+
+    constructor(
+        address _l2CrossDomain,
+        uint32  _sourceDomain,
+        address _l1Authority
+    ) {
+        l2CrossDomain = _l2CrossDomain;
+        sourceDomain  = _sourceDomain;
+        l1Authority   = _l1Authority;
+    }
+
+    function _getL1MessageSender() internal view returns (address) {
+        return l1Authority;
+    }
+
+    function _onlyCrossChainMessage() internal view {
+        require(msg.sender == address(this), "Receiver/invalid-sender");
+    }
+
+    modifier onlyCrossChainMessage() {
+        _onlyCrossChainMessage();
+        _;
+    }
+
+    function handleReceiveMessage(
+        uint32 _sourceDomain,
+        bytes32 sender,
+        bytes calldata messageBody
+    ) external returns (bool) {
+        require(msg.sender == l2CrossDomain,                      "Receiver/invalid-sender");
+        require(_sourceDomain == sourceDomain,                    "Receiver/invalid-sourceDomain");
+        require(sender == bytes32(uint256(uint160(l1Authority))), "Receiver/invalid-l1Authority");
+
+        (bool success, bytes memory ret) = address(this).call(messageBody);
+        if (!success) {
+            assembly {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/CCTPReceiver.sol
+++ b/src/CCTPReceiver.sol
@@ -7,18 +7,18 @@ pragma solidity ^0.8.0;
  */
 abstract contract CCTPReceiver {
 
-    address public immutable destinationCrossDomain;
-    uint32 public immutable  sourceDomainId;
+    address public immutable destinationMessenger;
+    uint32  public immutable sourceDomainId;
     address public immutable sourceAuthority;
 
     constructor(
-        address _destinationCrossDomain,
+        address _destinationMessenger,
         uint32  _sourceDomainId,
         address _sourceAuthority
     ) {
-        destinationCrossDomain = _destinationCrossDomain;
-        sourceDomainId         = _sourceDomainId;
-        sourceAuthority        = _sourceAuthority;
+        destinationMessenger = _destinationMessenger;
+        sourceDomainId       = _sourceDomainId;
+        sourceAuthority      = _sourceAuthority;
     }
 
     function _onlyCrossChainMessage() internal view {
@@ -35,7 +35,7 @@ abstract contract CCTPReceiver {
         bytes32 sender,
         bytes calldata messageBody
     ) external returns (bool) {
-        require(msg.sender == destinationCrossDomain,                 "Receiver/invalid-sender");
+        require(msg.sender == destinationMessenger,                   "Receiver/invalid-sender");
         require(sourceDomainId == sourceDomain,                       "Receiver/invalid-sourceDomain");
         require(sender == bytes32(uint256(uint160(sourceAuthority))), "Receiver/invalid-sourceAuthority");
 

--- a/src/CCTPReceiver.sol
+++ b/src/CCTPReceiver.sol
@@ -7,18 +7,18 @@ pragma solidity ^0.8.0;
  */
 abstract contract CCTPReceiver {
 
-    address public immutable l2CrossDomain;
-    uint32 public immutable  sourceDomain;
-    address public immutable l1Authority;
+    address public immutable destinationCrossDomain;
+    uint32 public immutable  sourceDomainId;
+    address public immutable sourceAuthority;
 
     constructor(
-        address _l2CrossDomain,
-        uint32  _sourceDomain,
-        address _l1Authority
+        address _destinationCrossDomain,
+        uint32  _sourceDomainId,
+        address _sourceAuthority
     ) {
-        l2CrossDomain = _l2CrossDomain;
-        sourceDomain  = _sourceDomain;
-        l1Authority   = _l1Authority;
+        destinationCrossDomain = _destinationCrossDomain;
+        sourceDomainId         = _sourceDomainId;
+        sourceAuthority        = _sourceAuthority;
     }
 
     function _onlyCrossChainMessage() internal view {
@@ -31,13 +31,13 @@ abstract contract CCTPReceiver {
     }
 
     function handleReceiveMessage(
-        uint32 _sourceDomain,
+        uint32 sourceDomain,
         bytes32 sender,
         bytes calldata messageBody
     ) external returns (bool) {
-        require(msg.sender == l2CrossDomain,                      "Receiver/invalid-sender");
-        require(_sourceDomain == sourceDomain,                    "Receiver/invalid-sourceDomain");
-        require(sender == bytes32(uint256(uint160(l1Authority))), "Receiver/invalid-l1Authority");
+        require(msg.sender == destinationCrossDomain,                 "Receiver/invalid-sender");
+        require(sourceDomainId == sourceDomain,                       "Receiver/invalid-sourceDomain");
+        require(sender == bytes32(uint256(uint160(sourceAuthority))), "Receiver/invalid-sourceAuthority");
 
         (bool success, bytes memory ret) = address(this).call(messageBody);
         if (!success) {

--- a/src/CCTPReceiver.sol
+++ b/src/CCTPReceiver.sol
@@ -21,10 +21,6 @@ abstract contract CCTPReceiver {
         l1Authority   = _l1Authority;
     }
 
-    function _getL1MessageSender() internal view returns (address) {
-        return l1Authority;
-    }
-
     function _onlyCrossChainMessage() internal view {
         require(msg.sender == address(this), "Receiver/invalid-sender");
     }

--- a/src/XChainForwarders.sol
+++ b/src/XChainForwarders.sol
@@ -32,6 +32,14 @@ interface ICrossDomainZkEVM {
     ) external payable;
 }
 
+interface ICrossDomainCircleCCTP {
+    function sendMessage(
+        uint32 destinationDomain,
+        bytes32 recipient,
+        bytes calldata messageBody
+    ) external;
+}
+
 /**
  * @title XChainForwarders
  * @notice Helper functions to abstract over L1 -> L2 message passing.
@@ -193,6 +201,61 @@ library XChainForwarders {
             destinationAddress,
             true,
             metadata
+        );
+    }
+
+    /// ================================ CCTP ================================
+
+    function sendMessageCCTP(
+        address l1CrossDomain,
+        uint32 destinationDomain,
+        bytes32 recipient,
+        bytes memory messageBody
+    ) internal {
+        ICrossDomainCircleCCTP(l1CrossDomain).sendMessage(
+            destinationDomain,
+            recipient,
+            messageBody
+        );
+    }
+
+    function sendMessageCCTP(
+        address l1CrossDomain,
+        uint32 destinationDomain,
+        address recipient,
+        bytes memory messageBody
+    ) internal {
+        sendMessageCCTP(
+            l1CrossDomain,
+            destinationDomain,
+            bytes32(uint256(uint160(recipient))),
+            messageBody
+        );
+    }
+
+    function sendMessageCircleCCTP(
+        uint32 destinationDomain,
+        bytes32 recipient,
+        bytes memory messageBody
+    ) internal {
+        sendMessageCCTP(
+            0x0a992d191DEeC32aFe36203Ad87D7d289a738F81,
+            destinationDomain,
+            recipient,
+            messageBody
+        );
+    }
+
+    function sendMessageCircleCCTP(
+        uint32 destinationDomain,
+        address recipient,
+        bytes memory messageBody
+    ) internal {
+        sendMessageCCTP(
+            0x0a992d191DEeC32aFe36203Ad87D7d289a738F81,
+            destinationDomain,
+            bytes32(uint256(uint160(recipient))),
+            messageBody
         );
     }
 

--- a/src/XChainForwarders.sol
+++ b/src/XChainForwarders.sol
@@ -207,12 +207,12 @@ library XChainForwarders {
     /// ================================ CCTP ================================
 
     function sendMessageCCTP(
-        address sourceCrossDomain,
+        address sourceMessenger,
         uint32 destinationDomainId,
         bytes32 recipient,
         bytes memory messageBody
     ) internal {
-        ICrossDomainCircleCCTP(sourceCrossDomain).sendMessage(
+        ICrossDomainCircleCCTP(sourceMessenger).sendMessage(
             destinationDomainId,
             recipient,
             messageBody
@@ -220,13 +220,13 @@ library XChainForwarders {
     }
 
     function sendMessageCCTP(
-        address sourceCrossDomain,
+        address sourceMessenger,
         uint32 destinationDomainId,
         address recipient,
         bytes memory messageBody
     ) internal {
         sendMessageCCTP(
-            sourceCrossDomain,
+            sourceMessenger,
             destinationDomainId,
             bytes32(uint256(uint160(recipient))),
             messageBody

--- a/src/XChainForwarders.sol
+++ b/src/XChainForwarders.sol
@@ -207,53 +207,53 @@ library XChainForwarders {
     /// ================================ CCTP ================================
 
     function sendMessageCCTP(
-        address l1CrossDomain,
-        uint32 destinationDomain,
+        address sourceCrossDomain,
+        uint32 destinationDomainId,
         bytes32 recipient,
         bytes memory messageBody
     ) internal {
-        ICrossDomainCircleCCTP(l1CrossDomain).sendMessage(
-            destinationDomain,
+        ICrossDomainCircleCCTP(sourceCrossDomain).sendMessage(
+            destinationDomainId,
             recipient,
             messageBody
         );
     }
 
     function sendMessageCCTP(
-        address l1CrossDomain,
-        uint32 destinationDomain,
+        address sourceCrossDomain,
+        uint32 destinationDomainId,
         address recipient,
         bytes memory messageBody
     ) internal {
         sendMessageCCTP(
-            l1CrossDomain,
-            destinationDomain,
+            sourceCrossDomain,
+            destinationDomainId,
             bytes32(uint256(uint160(recipient))),
             messageBody
         );
     }
 
     function sendMessageCircleCCTP(
-        uint32 destinationDomain,
+        uint32 destinationDomainId,
         bytes32 recipient,
         bytes memory messageBody
     ) internal {
         sendMessageCCTP(
             0x0a992d191DEeC32aFe36203Ad87D7d289a738F81,
-            destinationDomain,
+            destinationDomainId,
             recipient,
             messageBody
         );
     }
 
     function sendMessageCircleCCTP(
-        uint32 destinationDomain,
+        uint32 destinationDomainId,
         address recipient,
         bytes memory messageBody
     ) internal {
         sendMessageCCTP(
             0x0a992d191DEeC32aFe36203Ad87D7d289a738F81,
-            destinationDomain,
+            destinationDomainId,
             bytes32(uint256(uint160(recipient))),
             messageBody
         );

--- a/src/testing/CircleCCTPDomain.sol
+++ b/src/testing/CircleCCTPDomain.sol
@@ -22,7 +22,7 @@ contract CircleCCTPDomain is BridgedDomain {
     uint256 internal lastToHostLogIndex;
 
     constructor(StdChains.Chain memory _chain, Domain _hostDomain) Domain(_chain) BridgedDomain(_hostDomain) {
-        SOURCE_MESSENGER = MessengerLike(_getMessengerFromChainAlias(_hostDomain.details().chainAlias));
+        SOURCE_MESSENGER      = MessengerLike(_getMessengerFromChainAlias(_hostDomain.details().chainAlias));
         DESTINATION_MESSENGER = MessengerLike(_getMessengerFromChainAlias(_chain.chainAlias));
 
         // Set minimum required signatures to zero for both domains

--- a/src/testing/CircleCCTPDomain.sol
+++ b/src/testing/CircleCCTPDomain.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.8.0;
+
+import { StdChains } from "forge-std/StdChains.sol";
+import { Vm }        from "forge-std/Vm.sol";
+
+import { Domain, BridgedDomain } from "./BridgedDomain.sol";
+import { RecordedLogs }          from "./RecordedLogs.sol";
+
+interface MessengerLike {
+    function receiveMessage(bytes calldata message, bytes calldata attestation) external returns (bool success);
+}
+
+contract CircleCCTPDomain is BridgedDomain {
+
+    bytes32 private constant SENT_MESSAGE_TOPIC = keccak256("MessageSent(bytes)");
+
+    MessengerLike public constant L1_MESSENGER = MessengerLike(0x0a992d191DEeC32aFe36203Ad87D7d289a738F81);
+    MessengerLike public L2_MESSENGER;
+
+    uint256 internal lastFromHostLogIndex;
+    uint256 internal lastToHostLogIndex;
+
+    constructor(StdChains.Chain memory _chain, Domain _hostDomain) Domain(_chain) BridgedDomain(_hostDomain) {
+        bytes32 name = keccak256(bytes(_chain.chainAlias));
+        if (name == keccak256("avalanche")) {
+            L2_MESSENGER = MessengerLike(0x8186359aF5F57FbB40c6b14A588d2A59C0C29880);
+        } else if (name == keccak256("optimism")) {
+            L2_MESSENGER = MessengerLike(0x4D41f22c5a0e5c74090899E5a8Fb597a8842b3e8);
+        } else if (name == keccak256("arbitrum_one")) {
+            L2_MESSENGER = MessengerLike(0xC30362313FBBA5cf9163F0bb16a0e01f01A896ca);
+        } else if (name == keccak256("base")) {
+            L2_MESSENGER = MessengerLike(0xAD09780d193884d503182aD4588450C416D6F9D4);
+        } else if (name == keccak256("polygon")) {
+            L2_MESSENGER = MessengerLike(0xF3be9355363857F3e001be68856A2f96b4C39Ba9);
+        } else {
+            revert("Unsupported chain");
+        }
+
+        selectFork();
+
+        // Set minimum required signatures to zero
+        vm.store(
+            address(L2_MESSENGER),
+            bytes32(uint256(4)),
+            0
+        );
+
+        hostDomain.selectFork();
+
+        vm.store(
+            address(L1_MESSENGER),
+            bytes32(uint256(4)),
+            0
+        );
+
+        vm.recordLogs();
+    }
+
+    function relayFromHost(bool switchToGuest) external override {
+        selectFork();
+
+        // Read all L1 -> L2 messages and relay them under CCTP fork
+        Vm.Log[] memory logs = RecordedLogs.getLogs();
+        for (; lastFromHostLogIndex < logs.length; lastFromHostLogIndex++) {
+            Vm.Log memory log = logs[lastFromHostLogIndex];
+            if (log.topics[0] == SENT_MESSAGE_TOPIC && log.emitter == address(L1_MESSENGER)) {
+                L2_MESSENGER.receiveMessage(log.data, "");
+            }
+        }
+
+        if (!switchToGuest) {
+            hostDomain.selectFork();
+        }
+    }
+
+    function relayToHost(bool switchToHost) external override {
+        hostDomain.selectFork();
+
+        // Read all L2 -> L1 messages and relay them under host fork
+        Vm.Log[] memory logs = RecordedLogs.getLogs();
+        for (; lastToHostLogIndex < logs.length; lastToHostLogIndex++) {
+            Vm.Log memory log = logs[lastToHostLogIndex];
+            if (log.topics[0] == SENT_MESSAGE_TOPIC && log.emitter == address(L2_MESSENGER)) {
+                L1_MESSENGER.receiveMessage(log.data, "");
+            }
+        }
+
+        if (!switchToHost) {
+            selectFork();
+        }
+    }
+
+}

--- a/test/CCTPIntegration.t.sol
+++ b/test/CCTPIntegration.t.sol
@@ -27,6 +27,8 @@ contract MessageOrderingCCTP is MessageOrdering, CCTPReceiver {
 
 contract CircleCCTPIntegrationTest is IntegrationBaseTest {
 
+    address l2Authority = makeAddr("l2Authority");
+
     function test_avalanche() public {
         CircleCCTPDomain cctp = new CircleCCTPDomain(getChain("avalanche"), mainnet);
         checkCircleCCTPStyle(cctp, 1);
@@ -61,7 +63,7 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         MessageOrderingCCTP moHost = new MessageOrderingCCTP(
             address(cctp.SOURCE_MESSENGER()),
             destinationDomainId,
-            l1Authority
+            l2Authority
         );
 
         cctp.selectFork();
@@ -73,7 +75,7 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         );
 
         // Queue up some L2 -> L1 messages
-        vm.startPrank(l1Authority);
+        vm.startPrank(l2Authority);
         XChainForwarders.sendMessageCCTP(
             address(cctp.DESTINATION_MESSENGER()),
             sourceDomainId,

--- a/test/CCTPIntegration.t.sol
+++ b/test/CCTPIntegration.t.sol
@@ -10,12 +10,12 @@ import { CCTPReceiver } from "../src/CCTPReceiver.sol";
 contract MessageOrderingCCTP is MessageOrdering, CCTPReceiver {
 
     constructor(
-        address _l2CrossDomain,
-        uint32  _sourceDomain,
+        address _destinationMessenger,
+        uint32  _sourceDomainId,
         address _sourceAuthority
     ) CCTPReceiver(
-        _l2CrossDomain,
-        _sourceDomain,
+        _destinationMessenger,
+        _sourceDomainId,
         _sourceAuthority
     ) {}
 

--- a/test/CCTPIntegration.t.sol
+++ b/test/CCTPIntegration.t.sol
@@ -59,7 +59,7 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         host.selectFork();
 
         MessageOrderingCCTP moHost = new MessageOrderingCCTP(
-            address(cctp.L1_MESSENGER()),
+            address(cctp.SOURCE_MESSENGER()),
             guestDomain,
             l1Authority
         );
@@ -67,7 +67,7 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         cctp.selectFork();
 
         MessageOrderingCCTP moCCTP = new MessageOrderingCCTP(
-            address(cctp.L2_MESSENGER()),
+            address(cctp.DESTINATION_MESSENGER()),
             hostDomain,
             l1Authority
         );
@@ -75,13 +75,13 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         // Queue up some L2 -> L1 messages
         vm.startPrank(l1Authority);
         XChainForwarders.sendMessageCCTP(
-            address(cctp.L2_MESSENGER()),
+            address(cctp.DESTINATION_MESSENGER()),
             hostDomain,
             address(moHost),
             abi.encodeWithSelector(MessageOrdering.push.selector, 3)
         );
         XChainForwarders.sendMessageCCTP(
-            address(cctp.L2_MESSENGER()),
+            address(cctp.DESTINATION_MESSENGER()),
             hostDomain,
             address(moHost),
             abi.encodeWithSelector(MessageOrdering.push.selector, 4)
@@ -141,7 +141,7 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         moCCTP.handleReceiveMessage(0, bytes32(uint256(uint160(l1Authority))), abi.encodeWithSelector(MessageOrdering.push.selector, 999));
 
         assertEq(moCCTP.sourceDomain(), 0);
-        vm.prank(address(cctp.L2_MESSENGER()));
+        vm.prank(address(cctp.DESTINATION_MESSENGER()));
         vm.expectRevert("Receiver/invalid-sourceDomain");
         moCCTP.handleReceiveMessage(1, bytes32(uint256(uint160(l1Authority))), abi.encodeWithSelector(MessageOrdering.push.selector, 999));
     }

--- a/test/CCTPIntegration.t.sol
+++ b/test/CCTPIntegration.t.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.8.0;
+
+import "./IntegrationBase.t.sol";
+
+import { CircleCCTPDomain } from "../src/testing/CircleCCTPDomain.sol";
+
+import { CCTPReceiver } from "../src/CCTPReceiver.sol";
+
+contract MessageOrderingCCTP is MessageOrdering, CCTPReceiver {
+
+    constructor(
+        address _l2CrossDomain,
+        uint32  _chainId,
+        address _l1Authority
+    ) CCTPReceiver(
+        _l2CrossDomain,
+        _chainId,
+        _l1Authority
+    ) {}
+
+    function push(uint256 messageId) public override onlyCrossChainMessage {
+        super.push(messageId);
+    }
+
+}
+
+contract CircleCCTPIntegrationTest is IntegrationBaseTest {
+
+    function test_optimism() public {
+        CircleCCTPDomain cctp = new CircleCCTPDomain(getChain("optimism"), mainnet);
+        checkCircleCCTPStyle(cctp, 2);
+    }
+
+    function checkCircleCCTPStyle(CircleCCTPDomain cctp, uint32 guestDomain) public {
+        Domain host = cctp.hostDomain();
+
+        host.selectFork();
+
+        MessageOrdering moHost = new MessageOrdering();
+
+        cctp.selectFork();
+
+        MessageOrderingCCTP moCCTP = new MessageOrderingCCTP(
+            address(cctp.L2_MESSENGER()),
+            0,  // Ethereum
+            l1Authority
+        );
+
+        // Queue up some L2 -> L1 messages
+        XChainForwarders.sendMessageCCTP(
+            address(cctp.L2_MESSENGER()),
+            0,  // Ethereum
+            address(moHost),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 3)
+        );
+        XChainForwarders.sendMessageCCTP(
+            address(cctp.L2_MESSENGER()),
+            0,
+            address(moHost),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 4)
+        );
+
+        assertEq(moCCTP.length(), 0);
+
+        // Do not relay right away
+        host.selectFork();
+
+        // Queue up two more L1 -> L2 messages
+        vm.startPrank(l1Authority);
+        XChainForwarders.sendMessageCircleCCTP(
+            guestDomain,
+            address(moCCTP),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 1)
+        );
+        XChainForwarders.sendMessageCircleCCTP(
+            guestDomain,
+            address(moCCTP),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 2)
+        );
+        vm.stopPrank();
+
+        assertEq(moHost.length(), 0);
+
+        cctp.relayFromHost(true);
+
+        assertEq(moCCTP.length(), 2);
+        assertEq(moCCTP.messages(0), 1);
+        assertEq(moCCTP.messages(1), 2);
+
+        cctp.relayToHost(true);
+
+        assertEq(moHost.length(), 2);
+        assertEq(moHost.messages(0), 3);
+        assertEq(moHost.messages(1), 4);
+
+        return;
+
+        // Validate the message receiver failure modes
+        vm.startPrank(notL1Authority);
+        XChainForwarders.sendMessageCircleCCTP(
+            guestDomain,
+            address(moCCTP),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 999)
+        );
+        vm.stopPrank();
+
+        vm.expectRevert("handleReceiveMessage() failed");
+        cctp.relayFromHost(true);
+
+        cctp.selectFork();
+        vm.expectRevert("Receiver/invalid-sender");
+        moCCTP.push(999);
+
+        // TODO test the source domain doesn't match will revert
+    }
+
+}

--- a/test/CCTPIntegration.t.sol
+++ b/test/CCTPIntegration.t.sol
@@ -27,6 +27,11 @@ contract MessageOrderingCCTP is MessageOrdering, CCTPReceiver {
 
 contract CircleCCTPIntegrationTest is IntegrationBaseTest {
 
+    function test_avalanche() public {
+        CircleCCTPDomain cctp = new CircleCCTPDomain(getChain("avalanche"), mainnet);
+        checkCircleCCTPStyle(cctp, 1);
+    }
+
     function test_optimism() public {
         CircleCCTPDomain cctp = new CircleCCTPDomain(getChain("optimism"), mainnet);
         checkCircleCCTPStyle(cctp, 2);
@@ -40,6 +45,11 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
     function test_base() public {
         CircleCCTPDomain cctp = new CircleCCTPDomain(getChain("base"), mainnet);
         checkCircleCCTPStyle(cctp, 6);
+    }
+
+    function test_polygon() public {
+        CircleCCTPDomain cctp = new CircleCCTPDomain(getChain("polygon"), mainnet);
+        checkCircleCCTPStyle(cctp, 7);
     }
 
     function checkCircleCCTPStyle(CircleCCTPDomain cctp, uint32 guestDomain) public {


### PR DESCRIPTION
Adding Circle CCTP support. Please note the naming scheme: anything labelled with just "CCTP" means the protocol itself and anything labelled with "CircleCCTP" refers to the instance that Circle controls.

CCTP is a general protocol so in theory it could be used by another operator.